### PR TITLE
[Sheetmetal] Python 3.11.x and above Json Fix

### DIFF
--- a/SheetMetalBaseCmd.py
+++ b/SheetMetalBaseCmd.py
@@ -284,6 +284,17 @@ class SMBaseViewProvider:
             doc = FreeCAD.ActiveDocument  # crap
             self.Object = doc.getObject(state["ObjectName"])
 
+    # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        if state is not None:
+            import FreeCAD
+
+            doc = FreeCAD.ActiveDocument  # crap
+            self.Object = doc.getObject(state["ObjectName"])
+
     def claimChildren(self):
         objs = []
         if hasattr(self.Object, "BendSketch"):

--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -190,9 +190,17 @@ class SMBaseShapeViewProviderFlat:
         #        return {'ObjectName' : self.Object.Name}
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
         if state is not None:
-          self.Object = FreeCAD.ActiveDocument.getObject(state['ObjectName'])
+            self.Object = FreeCAD.ActiveDocument.getObject(state['ObjectName'])
+
+    # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        if state is not None:
+            self.Object = FreeCAD.ActiveDocument.getObject(state['ObjectName'])
 
     def claimChildren(self):
         return []

--- a/SheetMetalBend.py
+++ b/SheetMetalBend.py
@@ -175,7 +175,17 @@ class SMBendViewProviderTree:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -233,7 +243,17 @@ class SMBendViewProviderFlat:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -1421,6 +1421,17 @@ class SMViewProviderTree:
             doc = FreeCAD.ActiveDocument  # crap
             self.Object = doc.getObject(state["ObjectName"])
 
+    # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        if state is not None:
+            import FreeCAD
+
+            doc = FreeCAD.ActiveDocument  # crap
+            self.Object = doc.getObject(state["ObjectName"])
+
     def claimChildren(self):
         objs = []
         if hasattr(self.Object, "baseObject"):
@@ -1495,6 +1506,17 @@ class SMViewProviderFlat:
         return None
 
     def __setstate__(self, state):
+        if state is not None:
+            import FreeCAD
+
+            doc = FreeCAD.ActiveDocument  # crap
+            self.Object = doc.getObject(state["ObjectName"])
+
+    # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         if state is not None:
             import FreeCAD
 

--- a/SheetMetalCornerReliefCmd.py
+++ b/SheetMetalCornerReliefCmd.py
@@ -489,7 +489,17 @@ class SMCornerReliefVP:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -533,7 +543,17 @@ class SMCornerReliefPDVP:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap

--- a/SheetMetalExtendCmd.py
+++ b/SheetMetalExtendCmd.py
@@ -388,7 +388,17 @@ class SMViewProviderTree:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -448,7 +458,17 @@ class SMViewProviderFlat:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap

--- a/SheetMetalFoldCmd.py
+++ b/SheetMetalFoldCmd.py
@@ -295,7 +295,17 @@ class SMFoldViewProvider:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -339,7 +349,17 @@ class SMFoldPDViewProvider:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap

--- a/SheetMetalFormingCmd.py
+++ b/SheetMetalFormingCmd.py
@@ -228,7 +228,17 @@ class SMFormingVP:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -292,7 +302,17 @@ class SMFormingPDVP:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap

--- a/SheetMetalJunction.py
+++ b/SheetMetalJunction.py
@@ -160,7 +160,17 @@ class SMJViewProviderTree:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -218,14 +228,23 @@ class SMJViewProviderFlat:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
       self.Object = doc.getObject(state['ObjectName'])
 
   def claimChildren(self):
-
     return []
 
   def getIcon(self):

--- a/SheetMetalRelief.py
+++ b/SheetMetalRelief.py
@@ -207,7 +207,17 @@ class SMReliefViewProviderTree:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -265,7 +275,17 @@ class SMReliefViewProviderFlat:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap

--- a/SketchOnSheetMetalCmd.py
+++ b/SketchOnSheetMetalCmd.py
@@ -327,7 +327,17 @@ class SMSketchOnSheetVP:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap
@@ -371,7 +381,17 @@ class SMSketchOnSheetPDVP:
     #        return {'ObjectName' : self.Object.Name}
     return None
 
-  def __setstate__(self,state):
+  def __setstate__(self, state):
+    if state is not None:
+      import FreeCAD
+      doc = FreeCAD.ActiveDocument #crap
+      self.Object = doc.getObject(state['ObjectName'])
+
+  # dumps and loads replace __getstate__ and __setstate__ post v. 0.21.2
+  def dumps(self):
+    return None
+
+  def loads(self, state):
     if state is not None:
       import FreeCAD
       doc = FreeCAD.ActiveDocument #crap


### PR DESCRIPTION
In order to fix errors using Python 3.11.x and above while preserving ability for Python 3.10.x and below to still work correctly, example error:

```
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
<class 'TypeError'>: Object of type FeaturePython is not JSON serializable
17:04:02  PropertyPythonObject::toString(): failed for <class 'SheetMetalCmd.SMViewProviderFlat'>
17:04:02  pyException: Traceback (most recent call last):
  File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
```